### PR TITLE
Collabora default certificate type same as chosen by inventory variable

### DIFF
--- a/roles/collabora/vars/main.yml
+++ b/roles/collabora/vars/main.yml
@@ -10,4 +10,4 @@ tls_certificate_fullchain: "{{ tls_certificate_directory }}/ca-chain.cert.pem"
 tls_certificate_ca: "{{ tls_certificate_directory }}/ca.pem"
 tls_certificate_owner: lool
 tls_certificate_group: lool
-tls_certificate_type: selfsigned
+tls_certificate_type: "{{ nextcloud_certificate_type }}"


### PR DESCRIPTION
Since we enter nextcloud_certificate_type variable at the inventory, the collabora cert should use the same variable for its cert. Otherwise, if you obtain acme cert for nextcloud, you still get selfsigned cert for collabora.

Furthermore, for my installation I had to change this and also add the line "tls_certificate_test: false", but I can't seem to remember why right now, so I didn't include it in the PR, but it could be useful.