### PR TITLE
add explicit comment due to break of convention

### DIFF
--- a/inventory
+++ b/inventory
@@ -72,6 +72,7 @@ php_version                 = '8.0'
 php_install_optional_packages = false
 
 # Use S3 Bucket as primary storage
+# Leave empty for disabling S3 storage
 objectstore_s3_key            = ''
 objectstore_s3_secret         = ''
 # objectstore_s3_bucket_name    = ''


### PR DESCRIPTION
configuration of S3 storage breaks conventions of being enable/disabled by setting a variable true/false. In this case S3 variables have to == ''.