### PR TITLE
Nextcloud reloaded: Avoid sys/kernel changes in container

### DIFF
--- a/roles/os/tasks/tuning.yml
+++ b/roles/os/tasks/tuning.yml
@@ -1,10 +1,6 @@
 ---
 # performance and sercurity tuning
 
-- name: check for virtualization
-  ansible.builtin.shell: "systemd-detect-virt -c"
-  register: virtualization_type
-
 - name: sysctl vm.overcommit_memory=1
   sysctl: 
     name: vm.overcommit_memory
@@ -12,7 +8,7 @@
     state: present
     reload: true
     sysctl_file: /etc/sysctl.conf
-  when: virtualization_type is none
+  when: ansible_virtualization_type not in [ 'docker', 'podman', 'lxc', 'container', 'containerd' ]
 
 - name: sysctl -w net.core.somaxconn=65535
   sysctl:
@@ -21,13 +17,13 @@
     state: present
     reload: true
     sysctl_file: /etc/sysctl.conf
-  when: virtualization_type is none
+  when: ansible_virtualization_type not in [ 'docker', 'podman', 'lxc', 'container', 'containerd' ]
 
 - name: check /sys/kernel/mm/transparent_hugepage/enabled 
   stat:
     path: /sys/kernel/mm/transparent_hugepage/enabled
   register: hugepage_enabled
-  when: virtualization_type is none
+  when: ansible_virtualization_type not in [ 'docker', 'podman', 'lxc', 'container', 'containerd' ]
 
 - name: disable transparent hugepages
   block:

--- a/roles/os/tasks/tuning.yml
+++ b/roles/os/tasks/tuning.yml
@@ -1,6 +1,10 @@
 ---
 # performance and sercurity tuning
 
+- name: check for virtualization
+  ansible.builtin.shell: "systemd-detect-virt -c"
+  register: virtualization_type
+
 - name: sysctl vm.overcommit_memory=1
   sysctl: 
     name: vm.overcommit_memory
@@ -8,6 +12,7 @@
     state: present
     reload: true
     sysctl_file: /etc/sysctl.conf
+  when: virtualization_type is none
 
 - name: sysctl -w net.core.somaxconn=65535
   sysctl:
@@ -16,11 +21,13 @@
     state: present
     reload: true
     sysctl_file: /etc/sysctl.conf
+  when: virtualization_type is none
 
 - name: check /sys/kernel/mm/transparent_hugepage/enabled 
   stat:
     path: /sys/kernel/mm/transparent_hugepage/enabled
   register: hugepage_enabled
+  when: virtualization_type is none
 
 - name: disable transparent hugepages
   block:

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -21,6 +21,10 @@
     groups: redis
   when: groups['redis'] == groups['webserver']
 
+- name: check for virtualization
+  ansible.builtin.shell: "systemd-detect-virt -c"
+  register: virtualization_type
+
 - name: sysctl vm.overcommit_memory=1
   sysctl:
     name: vm.overcommit_memory
@@ -28,6 +32,7 @@
     state: present
     reload: true
     sysctl_file: /etc/sysctl.conf
+  when: virtualization_type is none
 
 - name: start and enable redis
   systemd:

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -21,10 +21,6 @@
     groups: redis
   when: groups['redis'] == groups['webserver']
 
-- name: check for virtualization
-  ansible.builtin.shell: "systemd-detect-virt -c"
-  register: virtualization_type
-
 - name: sysctl vm.overcommit_memory=1
   sysctl:
     name: vm.overcommit_memory
@@ -32,7 +28,7 @@
     state: present
     reload: true
     sysctl_file: /etc/sysctl.conf
-  when: virtualization_type is none
+  when: ansible_virtualization_type not in [ 'docker', 'podman', 'lxc', 'container', 'containerd' ]
 
 - name: start and enable redis
   systemd:


### PR DESCRIPTION
Change the redis and os roles to avoid changes in sys/kernel parameters, if executed in a container.

Currently only containers are check (VMs should still execute the tasks). Details:
https://www.freedesktop.org/software/systemd/man/systemd-detect-virt.html