### PR TITLE
Don't force use of the credential_store value for DB password.

### DIFF
--- a/roles/nextcloud/tasks/configure/nextcloud.yml
+++ b/roles/nextcloud/tasks/configure/nextcloud.yml
@@ -36,7 +36,7 @@
     --database-host "{{ nextcloud_db_host }}" 
     --database-name {{ nextcloud_db }} 
     --database-user {{ nextcloud_db_user }} 
-    --database-pass {{ lookup('password', '{{ credential_store }}/database_secret chars=ascii_letters,digits length=32') }} 
+    --database-pass {{ nextcloud_db_passwd }} 
     --admin-user {{ nextcloud_admin }} 
     --admin-pass {{ nextcloud_passwd }} 
     --data-dir {{ nextcloud_data_dir }}


### PR DESCRIPTION
Currently, the ansible script forces use of the credential store's Nextcloud database password, even though currently this value is set within the playbook. If the value does not exist in user-defined values, a value is generated, placed in the credential store, and set for the playbook. 

This commit utilizes the playbook's variable instead of forcing use of the credential store's.